### PR TITLE
resolve __exit__ issue when not using WITH

### DIFF
--- a/v3_Class_Fix/log_helper_class.py
+++ b/v3_Class_Fix/log_helper_class.py
@@ -217,7 +217,7 @@ class ConfiguredLogger:
         return log_func_wrapper
 
 
-    def sol_wrapper(self, func):
+    def sol_wrapper(self, func, using_exit:bool = False):
         """
         Wrapper function to provide start and end logging
         for entire solution - meant to only run ONCE.
@@ -239,6 +239,9 @@ class ConfiguredLogger:
                 return rtn_data
             finally:
                 self.logger.debug("Ending:\t%s.%s", func.__module__, func.__name__)
+
+                if not using_exit:
+                    self.__exit__(None, None, None)
 
         return sol_func_wrapper
 

--- a/v3_Class_Fix/log_helper_class.py
+++ b/v3_Class_Fix/log_helper_class.py
@@ -259,7 +259,7 @@ func_wrapper = logger_obj.func_wrapper
 sol_wrapper = logger_obj.sol_wrapper
 
 
-@sol_wrapper
+@sol_wrapper(using_exit=False)
 @func_wrapper
 def main() -> None:
     """

--- a/v3_Class_Fix/main_prog.py
+++ b/v3_Class_Fix/main_prog.py
@@ -36,7 +36,7 @@ def crit_test() -> None:
 
     assert True is False, "Just testing failure! Does it still finish solution wrap?"
 
-@sol_wrapper
+@sol_wrapper(using_exit=False)
 @func_wrapper
 def main() -> None:
     """


### PR DESCRIPTION
Only able to use the dataclasses' `__exit__` when using built-in `with` ... unless utilizing this new update.

Also brings in teaching ability on how to have input with decorators.